### PR TITLE
Fixes readline input port bug

### DIFF
--- a/xrepl-lib/xrepl/xrepl.rkt
+++ b/xrepl-lib/xrepl/xrepl.rkt
@@ -43,6 +43,8 @@
 (defautoload scribble/xref          xref-binding->definition-tag)
 (defautoload scribble/blueboxes     fetch-blueboxes-strs make-blueboxes-cache)
 
+(define original-input-port (current-input-port))
+
 ;; similar, but just for identifiers
 (define hidden-namespace (make-base-namespace))
 (define initial-namespace (current-namespace))
@@ -442,7 +444,8 @@
                    (string-append "$EDITOR ("env") not found in your path")
                    "no $EDITOR variable"))
          (run-command 'drracket)]
-        [(not (apply system* exe (getarg 'path 'list #:default here-path)))
+        [(not (let ([arg (getarg 'path 'list #:default here-path)])
+                    (parameterize ([current-input-port original-input-port]) (apply system* exe arg))))
          (eprintf "; (exit with an error status)\n")]
         [else (void)]))
 


### PR DESCRIPTION
When using ",edit" command with terminal editors the actual input port is not terminal (because of readline). This commit fixes this issue by saving the input port pre readline, and using it when calling the
external editor.