### PR TITLE
Add section headings to the ,help menu

### DIFF
--- a/xrepl-lib/xrepl/xrepl.rkt
+++ b/xrepl-lib/xrepl/xrepl.rkt
@@ -14,7 +14,7 @@
 
 ;; ----------------------------------------------------------------------------
 
-(require racket/list racket/match scribble/text/wrap)
+(require racket/dict racket/list racket/match scribble/text/wrap)
 
 ;; ----------------------------------------------------------------------------
 ;; utilities
@@ -230,8 +230,13 @@
 
 (struct command (names argline blurb desc handler))
 (define commands (make-hasheq))
-(define commands-list '()) ; for help displays, in definition order
+;; For help displays: commands organized into sections, where sections are
+;; subdicts. Sections and items within each section are added in reverse
+;; definition order. Nested sections are printed correctly by ",help", but
+;; `defcommand-section' does not currently support defining nested sections.
+(define commands-dict null)
 (define current-command (make-parameter #f))
+(define current-commands-section (make-parameter commands-dict))
 (define (register-command! names blurb argline desc handler)
   (let* ([names (if (list? names) names (list names))]
          [cmd (command names blurb argline desc handler)])
@@ -239,11 +244,18 @@
       (if (hash-ref commands n #f)
         (error 'defcommand "duplicate command name: ~s" n)
         (hash-set! commands n cmd)))
-    (set! commands-list (cons cmd commands-list))))
+    (set! commands-dict (dict-update commands-dict
+                                     (current-commands-section)
+                                     (λ (sec-cmd-list) (cons cmd sec-cmd-list))))))
 (define-syntax-rule (defcommand cmd+aliases argline blurb [desc ...]
                       body0 body ...)
   (register-command! `cmd+aliases `argline `blurb `(desc ...)
                      (λ () body0 body ...)))
+(define (defcommand-section name)
+  (when (dict-has-key? commands-dict name)
+    (error 'defcommand-section "duplicate command section name: ~s" name))
+  (set! commands-dict (cons (cons name null) commands-dict))
+  (current-commands-section name))
 
 (define (cmderror fmt #:default-who [dwho #f] . args)
   (let ([cmd (current-command)])
@@ -348,6 +360,11 @@
       ((command-handler (or (hash-ref commands cmd #f)
                             (error "Unknown command:" cmd)))))))
 
+;; ----------------------------------------------------------------------------
+;; generic commands
+
+(defcommand-section "General commands")
+
 (defcommand (help h ?) "[<command-name>]"
   "display available commands"
   ["Lists known commands and their help; use with a command name to get"
@@ -356,24 +373,30 @@
   (define cmd
     (and arg (hash-ref commands arg
                        (λ () (printf "*** Unknown command: `~s'\n" arg) #f))))
-  (define (show-cmd cmd indent)
+  (define (indentation-string indent-level)
+    (string-append "; " (make-string (* 2 indent-level) #\space)))
+  (define (show-cmd cmd indent-level)
     (define names (command-names cmd))
-    (printf "~a~s" indent (car names))
+    (printf "~a~s" (indentation-string indent-level) (car names))
     (when (pair? (cdr names)) (printf " ~s" (cdr names)))
     (printf ": ~a\n" (command-blurb cmd)))
+  (define (show-cmd-sec sec [indent-level 0])
+    (for ([(name commands-or-sections) (in-dict (reverse sec))])
+      (unless (null? commands-or-sections)
+        (printf "~a~a:\n" (indentation-string indent-level) name)
+        (for-each (λ (c) (if (dict? c)
+                             (show-cmd-sec c (add1 indent-level))
+                             (show-cmd c (add1 indent-level))))
+                  (reverse commands-or-sections)))))
   (with-wrapped-output
-    (if cmd
-      (begin (show-cmd cmd "; ")
-             (printf ";   usage: ,~a" arg)
-             (let ([a (command-argline cmd)]) (when a (printf " ~a" a)))
-             (printf "\n")
-             (for ([d (in-list (command-desc cmd))])
-               (printf "; ~a\n" d)))
-      (begin (printf "; Available commands:\n")
-             (for-each (λ (c) (show-cmd c ";   ")) (reverse commands-list))))))
-
-;; ----------------------------------------------------------------------------
-;; generic commands
+   (if cmd
+       (begin (show-cmd cmd "; ")
+              (printf ";   usage: ,~a" arg)
+              (let ([a (command-argline cmd)]) (when a (printf " ~a" a)))
+              (printf "\n")
+              (for ([d (in-list (command-desc cmd))])
+                (printf "; ~a\n" d)))
+       (show-cmd-sec commands-dict))))
 
 (defcommand (exit quit ex) "[<exit-code>]"
   "exit racket"
@@ -584,6 +607,8 @@
 ;; ----------------------------------------------------------------------------
 ;; binding related commands
 
+(defcommand-section "Binding information")
+
 (defcommand (apropos ap) "<search-for> ..."
   "look for a binding"
   ["Additional arguments restrict the shown matches.  The search specs can"
@@ -747,6 +772,8 @@
 ;; ----------------------------------------------------------------------------
 ;; require/load commands
 
+(defcommand-section "Requiring and loading")
+
 (defcommand (require req r) "<require-spec> ...+"
   "require a module"
   ["The arguments are usually passed to `require', unless an argument"
@@ -812,6 +839,8 @@
 
 ;; ----------------------------------------------------------------------------
 ;; debugging commands
+
+(defcommand-section "Debugging")
 
 ;; not useful: catches only escape continuations
 ;; (define last-break-exn (make-parameter #f))
@@ -1029,6 +1058,8 @@
 
 ;; ----------------------------------------------------------------------------
 ;; namespace switching
+
+(defcommand-section "Miscellaneous")
 
 (define default-namespace-name '*)
 (define current-namespace-name (make-parameter default-namespace-name))


### PR DESCRIPTION
It's always hard for me to find what I'm looking for in the list of commands.  This is what the help menu looks like with this change:
```
-> ,help
; General commands:
;   help (h ?): display available commands
;   exit (quit ex): exit racket
;   cd: change the current directory
;   pwd: display the current directory
;   shell (sh ls cp mv rm md rd git svn): run a shell command
;   edit (e): edit files in your $EDITOR
;   drracket (dr drr): edit files in DrRacket
; Binding information:
;   apropos (ap): look for a binding
;   describe (desc id): describe a (bound) identifier
;   doc: browse the racket documentation
; Requiring and loading:
;   require (req r): require a module
;   require-reloadable (reqr rr): require a module, make it reloadable
;   enter (en): require a module and go into its namespace
;   toplevel (top): go back to the toplevel
;   load (ld): load a file
; Debugging:
;   backtrace (bt): see a backtrace of the last exception
;   time: time an expression
;   trace (tr): trace a function
;   untrace (untr): untrace a function
;   errortrace (errt inst): errortrace instrumentation control
;   profile (prof): profiler control
;   execution-counts: execution counts
;   coverage (cover): coverage information via a sandbox
; Miscellaneous:
;   switch-namespace (switch): switch to a different repl namespace
;   syntax (stx st): set syntax object to inspect, and control it
;   check-requires (ckreq): check the `require's of a module
;   log: control log output
;   install!: install xrepl in your Racket init file
```