### PR TITLE
Update xrepl.rkt - fix path->string issues on Windows

### DIFF
--- a/xrepl-lib/xrepl/xrepl.rkt
+++ b/xrepl-lib/xrepl/xrepl.rkt
@@ -114,8 +114,8 @@
     ;; "~/..." path.
     (if (not (complete-path? x)) ; shouldn't happen
       x
-      (let* ([r (path->string (find-relative-path (current-directory) x))]
-             [h (path->string (let ([p (find-relative-path home-dir x)])
+      (let* ([r (path->string (find-relative-path (current-directory) (string->path x)))]
+             [h (path->string (let ([p (find-relative-path home-dir (string->path x))])
                                 ;; On Windows, HOME might be on a different
                                 ;; volume, so make sure we get a relative
                                 ;; path back:


### PR DESCRIPTION
Update xrepl.rkt - fix path->string issues on Windows when:
- drive holding module to `enter!` and home drive are on different volumes/drives,
- drive holding module to `enter!` and current drive are on different volumes/drives. 

See problem report: https://github.com/racket/racket/issues/2023